### PR TITLE
Dockerize cheeta-api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2.7-alpine
+
+LABEL maintainer="Marcos F. Lobo"
+
+RUN apk update && apk add postgresql-dev gcc python2-dev musl-dev
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "-m", "cheetahapi.main", "-c", "./etc/config.conf" ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,66 @@ Backend API for [cheetah](https://github.com/marcosflobo/cheetah) Web applicatio
 # Agile board
 Please checkout or [Kanban board](https://github.com/marcosflobo/cheetah/projects/1) to follow up the ongoing tasks.
 
+# Docker deployment
+The minimal setup is:
+- PostgreSQL database with data
+- Cheetah-api running and pointing to the PostgreSQL database
+
+For this, we provide Dockefiles for both services. We will:
+1. Setup configuration file
+2. Build PostgreSQL and cheetah-api Docker images
+3. Create a Docker network to be able to communicate both services
+4. Deploy PostgreSQL and cheetah-api Docker containers 
+## Setup configuration file
+Edit ./etc/config.conf file and set parameters
+```ini
+host = 0.0.0.0
+[...]
+db_host = cheetah_api_postgresql_test
+```
+Save the file and let't create the Docker image
+
+## Build docker image cheetah-api
+From the project dir, run
+```bash
+docker build -t cheetah_api .
+```
+
+## Build Docker image PostgreSQL
+From ./integration_tests dir, run:
+```bash
+docker build -t cheetah_api_postgresql .
+```
+Now we have the images created, let's setup the network and run the containers.
+
+## Create Docker network
+We need a Docker network to be able to communicate both services.
+```bash
+docker network create cheetah_net
+```
+Please note that, if you change here the network name, you have to change it too in the next docker commands.
+
+## Run PostgreSQL database as Docker container
+We provide a PostgreSQL Dockerfile with test data (See next chapter for this). You can build the image and then run the container.
+```bash
+docker run --rm -p 5432:5432 --net cheetah_net --name cheetah_api_postgresql_test cheetah_api_postgresql
+```
+
+## Run cheetah-api as Docker container
+We provide a Dockerfile to run cheetah-api service
+```bash
+docker run --rm -p 8081:80 --net cheetah_net --name cheetah-api cheetah_api:latest
+```
+Where 8081 is the port in your host and the 80 is the port configured for cheetah-api in etc/config.conf file.
+Please note that the container name for PostgreSQL service should be set in "db_host" parameter in ./etc/config.conf file. 
+
+## Testing the Docker environment
+From a host, just run:
+```bash
+curl -d '{"authenticate":{"username":"foo","password":"foo"}}' -H "Content-Type: application/json" -X POST http://localhost:8081/v1/authenticate
+```
+Please note that user "foo" with password "foo" is provided in the PostgreSQL Dockerfile as sample data.
+
 # Quick integration tests setup
 ## Setup PosgreSQL database using Docker
 1. Install docker in your system

--- a/etc/config.conf
+++ b/etc/config.conf
@@ -26,9 +26,11 @@ log_level = INFO
 log_format = %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 
 # Hostname of the server
-host = localhost
+# Default: 0.0.0.0
+host = 0.0.0.0
 
 # Port to listen
+# Default: 80
 port = 80
 
 [DATABASE]
@@ -39,8 +41,8 @@ port = 80
 db_driver = postgresql
 
 # Database host
-# Default: localhost
-db_host = localhost
+# Default: 0.0.0.0
+db_host = 0.0.0.0
 
 # Database port
 # Default: 5432
@@ -48,12 +50,12 @@ db_port = 5432
 
 # Database name
 # Default: cheetah-api
-db_name = cheetah-api
+db_name = docker
 
 # Database username
 # Default: cheetah-api
-db_username = cheetah-api
+db_username = docker
 
 # Database user password
 # Default: cheetah-api
-db_pwd = cheetah-api
+db_pwd = docker

--- a/integration_tests/docker_up.sh
+++ b/integration_tests/docker_up.sh
@@ -1,2 +1,2 @@
 docker build -t cheetah_api_postgresql .
-docker run --rm -P --name cheetah_api_postgresql_test cheetah_api_postgresql
+docker run --rm -p 5432:5432 --net cheetah_net --name cheetah_api_postgresql_test cheetah_api_postgresql


### PR DESCRIPTION
- Create dockerfile to run cheetah-api
- Update documentation to explain how to setup the service using Docker containters
- Change default value in config.conf file